### PR TITLE
Add ClientIdExt / RenetClientIdExt for ClientId conversion

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -4,6 +4,8 @@ use bevy_renet::{self, renet::RenetClient, RenetClientPlugin, RenetReceive, Rene
 use bevy_renet::{renet::transport::NetcodeClientTransport, transport::NetcodeClientPlugin};
 use bevy_replicon::prelude::*;
 
+use crate::ClientIdExt;
+
 /// Adds renet as client messaging backend.
 ///
 /// Initializes [`RenetClientPlugin`] and systems that pass data between
@@ -56,7 +58,7 @@ impl RepliconRenetClientPlugin {
         // In renet only transport knows the ID.
         // TODO: Pending renet issue https://github.com/lucaspoffo/renet/issues/153
         #[cfg(feature = "renet_transport")]
-        let client_id = Some(ClientId::new(transport.client_id().raw()));
+        let client_id = Some(transport.client_id().as_client_id());
         #[cfg(not(feature = "renet_transport"))]
         let client_id = None;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,6 +138,30 @@ impl RenetChannelsExt for RepliconChannels {
     }
 }
 
+/// External trait for [`ClientId`] to provide convenient conversion into renet ClientId.
+pub trait RenetClientIdExt {
+    /// Returns server channel configs that can be used to create [`ConnectionConfig`](renet::ConnectionConfig).
+    fn as_renet_client_id(&self) -> renet::ClientId;
+}
+
+impl RenetClientIdExt for ClientId {
+    fn as_renet_client_id(&self) -> renet::ClientId {
+        renet::ClientId::from_raw(self.get())
+    }
+}
+
+/// External trait for [`ClientId`] to provide convenient conversion into ClientId.
+pub trait ClientIdExt {
+    /// Returns server channel configs that can be used to create [`ConnectionConfig`](renet::ConnectionConfig).
+    fn as_client_id(&self) -> ClientId;
+}
+
+impl ClientIdExt for renet::ClientId {
+    fn as_client_id(&self) -> ClientId {
+        ClientId::new(self.raw())
+    }
+}
+
 /// Converts replicon channels into renet channel configs.
 fn create_configs(channels: &[RepliconChannel], default_max_bytes: usize) -> Vec<ChannelConfig> {
     let mut channel_configs = Vec::with_capacity(channels.len());

--- a/src/server.rs
+++ b/src/server.rs
@@ -7,6 +7,8 @@ use bevy_renet::{
 };
 use bevy_replicon::prelude::*;
 
+use crate::{ClientIdExt, RenetClientIdExt};
+
 /// Adds renet as server messaging backend.
 ///
 /// Initializes [`RenetServerPlugin`], systems that pass data between [`RenetServer`]
@@ -59,11 +61,11 @@ impl RepliconRenetServerPlugin {
         for event in renet_server_events.read() {
             let replicon_event = match event {
                 renet::ServerEvent::ClientConnected { client_id } => ServerEvent::ClientConnected {
-                    client_id: ClientId::new(client_id.raw()),
+                    client_id: client_id.as_client_id(),
                 },
                 renet::ServerEvent::ClientDisconnected { client_id, reason } => {
                     ServerEvent::ClientDisconnected {
-                        client_id: ClientId::new(client_id.raw()),
+                        client_id: client_id.as_client_id(),
                         reason: reason.to_string(),
                     }
                 }
@@ -80,7 +82,7 @@ impl RepliconRenetServerPlugin {
         mut replicon_server: ResMut<RepliconServer>,
     ) {
         for &client_id in connected_clients.iter() {
-            let renet_client_id = renet::ClientId::from_raw(client_id.get());
+            let renet_client_id = client_id.as_renet_client_id();
             for channel_id in 0..channels.client_channels().len() as u8 {
                 while let Some(message) = renet_server.receive_message(renet_client_id, channel_id)
                 {
@@ -95,7 +97,7 @@ impl RepliconRenetServerPlugin {
         mut replicon_server: ResMut<RepliconServer>,
     ) {
         for (client_id, channel_id, message) in replicon_server.drain_sent() {
-            let client_id = renet::ClientId::from_raw(client_id.get());
+            let client_id = client_id.as_renet_client_id();
             renet_server.send_message(client_id, channel_id, message)
         }
     }


### PR DESCRIPTION
As in the title, this just adds a couple External traits to make it cleaner to convert between `renet` `ClientId` and `bevy_replicon` `ClientId`