### PR TITLE
chore(deps): update to Bevy 0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ all-features = true
 
 [dependencies]
 bevy_replicon = { version = "0.29", default-features = false }
-bevy_renet = { git = "https://github.com/lucaspoffo/renet.git", branch = "master", default-features = false }
+bevy_renet = { version = "1.0", default-features = false }
 bevy = { version = "0.15", default-features = false }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_replicon_renet"
-version = "0.5.1"
+version = "0.6.0"
 authors = [
   "Hennadii Chernyshchyk <genaloner@gmail.com>",
   "koe <ukoe@protonmail.com>",
@@ -25,14 +25,14 @@ rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 all-features = true
 
 [dependencies]
-bevy_replicon = { version = "0.28", default-features = false }
-bevy_renet = { version = "0.0.12", default-features = false }
-bevy = { version = "0.14", default-features = false }
+bevy_replicon = { version = "0.29", default-features = false }
+bevy_renet = { git = "https://github.com/lucaspoffo/renet.git", branch = "master", default-features = false }
+bevy = { version = "0.15", default-features = false }
 
 [dev-dependencies]
 serde = "1.0"
 clap = { version = "4.1", features = ["derive"] }
-bevy = { version = "0.14", default-features = false, features = [
+bevy = { version = "0.15", default-features = false, features = [
   "bevy_text",
   "bevy_ui",
   "bevy_gizmos",
@@ -42,13 +42,12 @@ bevy = { version = "0.14", default-features = false, features = [
 ] }
 
 [features]
-default = ["client", "server", "renet_serde", "renet_transport"]
+default = ["client", "server", "renet_netcode"]
 server = ["bevy_replicon/server"]
 client = ["bevy_replicon/client"]
 
 # Re-exports of renet features
-renet_serde = ["bevy_renet/serde"]
-renet_transport = ["bevy_renet/transport"]
+renet_netcode = ["bevy_renet/netcode"]
 
 [[test]]
 name = "transport"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ client = ["bevy_replicon/client"]
 
 # Re-exports of renet features
 renet_netcode = ["bevy_renet/netcode"]
+renet_steam = ["bevy_renet/steam"]
 
 [[test]]
 name = "transport"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ bevy = { version = "0.15", default-features = false, features = [
   "bevy_ui",
   "bevy_gizmos",
   "bevy_state",
+  "bevy_window",
   "x11",
   "default_font",
 ] }
@@ -51,13 +52,13 @@ renet_netcode = ["bevy_renet/netcode"]
 renet_steam = ["bevy_renet/steam"]
 
 [[test]]
-name = "transport"
-required-features = ["server", "client", "renet_transport"]
+name = "netcode"
+required-features = ["server", "client", "renet_netcode"]
 
 [[example]]
 name = "simple_box"
-required-features = ["server", "client", "renet_transport"]
+required-features = ["server", "client", "renet_netcode"]
 
 [[example]]
 name = "tic_tac_toe"
-required-features = ["server", "client", "renet_transport"]
+required-features = ["server", "client", "renet_netcode"]

--- a/examples/simple_box.rs
+++ b/examples/simple_box.rs
@@ -14,13 +14,11 @@ use bevy::{
 };
 use bevy_replicon::prelude::*;
 use bevy_replicon_renet::{
-    renet::{
-        transport::{
-            ClientAuthentication, NetcodeClientTransport, NetcodeServerTransport,
-            ServerAuthentication, ServerConfig,
-        },
-        ConnectionConfig, RenetClient, RenetServer,
+    netcode::{
+        ClientAuthentication, NetcodeClientTransport, NetcodeServerTransport, ServerAuthentication,
+        ServerConfig,
     },
+    renet::{ConnectionConfig, RenetClient, RenetServer},
     RenetChannelsExt, RepliconRenetPlugins,
 };
 use clap::Parser;
@@ -73,11 +71,7 @@ impl SimpleBoxPlugin {
     ) -> Result<(), Box<dyn Error>> {
         match *cli {
             Cli::SinglePlayer => {
-                commands.spawn(PlayerBundle::new(
-                    ClientId::SERVER,
-                    Vec2::ZERO,
-                    GREEN.into(),
-                ));
+                commands.spawn((Player(ClientId::SERVER), PlayerColor(GREEN.into())));
             }
             Cli::Server { port } => {
                 let server_channels_config = channels.get_server_configs();
@@ -103,19 +97,15 @@ impl SimpleBoxPlugin {
                 commands.insert_resource(server);
                 commands.insert_resource(transport);
 
-                commands.spawn(TextBundle::from_section(
-                    "Server",
-                    TextStyle {
+                commands.spawn((
+                    Text::new("Server"),
+                    TextFont {
                         font_size: 30.0,
-                        color: Color::WHITE,
-                        ..default()
+                        ..Default::default()
                     },
+                    TextColor::WHITE,
                 ));
-                commands.spawn(PlayerBundle::new(
-                    ClientId::SERVER,
-                    Vec2::ZERO,
-                    GREEN.into(),
-                ));
+                commands.spawn((Player(ClientId::SERVER), PlayerColor(GREEN.into())));
             }
             Cli::Client { port, ip } => {
                 let server_channels_config = channels.get_server_configs();
@@ -142,13 +132,13 @@ impl SimpleBoxPlugin {
                 commands.insert_resource(client);
                 commands.insert_resource(transport);
 
-                commands.spawn(TextBundle::from_section(
-                    format!("Client: {client_id:?}"),
-                    TextStyle {
+                commands.spawn((
+                    Text(format!("Client: {client_id:?}")),
+                    TextFont {
                         font_size: 30.0,
-                        color: Color::WHITE,
                         ..default()
                     },
+                    TextColor::WHITE,
                 ));
             }
         }
@@ -157,7 +147,7 @@ impl SimpleBoxPlugin {
     }
 
     fn spawn_camera(mut commands: Commands) {
-        commands.spawn(Camera2dBundle::default());
+        commands.spawn(Camera2d);
     }
 
     /// Logs server events and spawns a new player whenever a client connects.
@@ -170,11 +160,7 @@ impl SimpleBoxPlugin {
                     let r = ((client_id.get() % 23) as f32) / 23.0;
                     let g = ((client_id.get() % 27) as f32) / 27.0;
                     let b = ((client_id.get() % 39) as f32) / 39.0;
-                    commands.spawn(PlayerBundle::new(
-                        *client_id,
-                        Vec2::ZERO,
-                        Color::srgb(r, g, b),
-                    ));
+                    commands.spawn((Player(*client_id), PlayerColor(Color::srgb(r, g, b))));
                 }
                 ServerEvent::ClientDisconnected { client_id, reason } => {
                     info!("{client_id:?} disconnected: {reason}");
@@ -227,7 +213,7 @@ impl SimpleBoxPlugin {
             info!("received event {event:?} from {client_id:?}");
             for (player, mut position) in &mut players {
                 if *client_id == player.0 {
-                    **position += event.0 * time.delta_seconds() * MOVE_SPEED;
+                    **position += event.0 * time.delta_secs() * MOVE_SPEED;
                 }
             }
         }
@@ -259,33 +245,15 @@ impl Default for Cli {
     }
 }
 
-#[derive(Bundle)]
-struct PlayerBundle {
-    player: Player,
-    position: PlayerPosition,
-    color: PlayerColor,
-    replicated: Replicated,
-}
-
-impl PlayerBundle {
-    fn new(client_id: ClientId, position: Vec2, color: Color) -> Self {
-        Self {
-            player: Player(client_id),
-            position: PlayerPosition(position),
-            color: PlayerColor(color),
-            replicated: Replicated,
-        }
-    }
-}
-
-/// Contains the client ID of a player.
+/// Contains player ID.
 #[derive(Component, Serialize, Deserialize)]
+#[require(PlayerPosition, PlayerColor, Replicated)]
 struct Player(ClientId);
 
-#[derive(Component, Deserialize, Serialize, Deref, DerefMut)]
+#[derive(Component, Deserialize, Serialize, Deref, DerefMut, Default)]
 struct PlayerPosition(Vec2);
 
-#[derive(Component, Deserialize, Serialize)]
+#[derive(Component, Deserialize, Serialize, Default)]
 struct PlayerColor(Color);
 
 /// A movement event for the controlled box.

--- a/examples/simple_box.rs
+++ b/examples/simple_box.rs
@@ -187,7 +187,6 @@ impl SimpleBoxPlugin {
         for (position, color) in &players {
             gizmos.rect(
                 Vec3::new(position.x, position.y, 0.0),
-                Quat::IDENTITY,
                 Vec2::ONE * 50.0,
                 color.0,
             );

--- a/examples/tic_tac_toe.rs
+++ b/examples/tic_tac_toe.rs
@@ -11,13 +11,11 @@ use std::{
 use bevy::prelude::*;
 use bevy_replicon::prelude::*;
 use bevy_replicon_renet::{
-    renet::{
-        transport::{
-            ClientAuthentication, NetcodeClientTransport, NetcodeServerTransport,
-            ServerAuthentication, ServerConfig,
-        },
-        ConnectionConfig, RenetClient, RenetServer,
+    netcode::{
+        ClientAuthentication, NetcodeClientTransport, NetcodeServerTransport, ServerAuthentication,
+        ServerConfig,
     },
+    renet::{ConnectionConfig, RenetClient, RenetServer},
     RenetChannelsExt, RepliconRenetPlugins,
 };
 use clap::{Parser, ValueEnum};
@@ -102,7 +100,7 @@ const SYMBOL_SECTION: usize = 1;
 
 impl TicTacToePlugin {
     fn setup_ui(mut commands: Commands, symbol_font: Res<SymbolFont>) {
-        commands.spawn(Camera2dBundle::default());
+        commands.spawn(Camera2d);
 
         const LINES_COUNT: usize = GRID_SIZE + 1;
 
@@ -118,121 +116,105 @@ impl TicTacToePlugin {
                 + LINE_THICKNESS / 2.0;
 
             // Horizontal
-            commands.spawn(SpriteBundle {
-                sprite: Sprite {
+            commands.spawn((
+                Sprite {
                     color: BOARD_COLOR,
                     ..Default::default()
                 },
-                transform: Transform {
+                Transform {
                     translation: Vec3::Y * position,
                     scale: Vec3::new(BOARD_SIZE, LINE_THICKNESS, 1.0),
                     ..Default::default()
                 },
-                ..Default::default()
-            });
+            ));
 
             // Vertical
-            commands.spawn(SpriteBundle {
-                sprite: Sprite {
+            commands.spawn((
+                Sprite {
                     color: BOARD_COLOR,
                     ..Default::default()
                 },
-                transform: Transform {
+                Transform {
                     translation: Vec3::X * position,
                     scale: Vec3::new(LINE_THICKNESS, BOARD_SIZE, 1.0),
                     ..Default::default()
                 },
-                ..Default::default()
-            });
+            ));
         }
 
         const BUTTON_SIZE: f32 = CELL_SIZE / 1.2;
         const BUTTON_MARGIN: f32 = (CELL_SIZE + LINE_THICKNESS - BUTTON_SIZE) / 2.0;
 
         const TEXT_COLOR: Color = Color::srgb(0.5, 0.5, 1.0);
-        const FONT_SIZE: f32 = 40.0;
+        const FONT_SIZE: f32 = 32.0;
 
         commands
-            .spawn(NodeBundle {
-                style: Style {
-                    width: Val::Percent(100.0),
-                    height: Val::Percent(100.0),
-                    align_items: AlignItems::Center,
-                    justify_content: JustifyContent::Center,
-                    ..Default::default()
-                },
+            .spawn(Node {
+                width: Val::Percent(100.0),
+                height: Val::Percent(100.0),
+                align_items: AlignItems::Center,
+                justify_content: JustifyContent::Center,
                 ..Default::default()
             })
             .with_children(|parent| {
                 parent
-                    .spawn(NodeBundle {
-                        style: Style {
-                            flex_direction: FlexDirection::Column,
-                            width: Val::Px(BOARD_SIZE - LINE_THICKNESS),
-                            height: Val::Px(BOARD_SIZE - LINE_THICKNESS),
-                            ..Default::default()
-                        },
+                    .spawn(Node {
+                        flex_direction: FlexDirection::Column,
+                        width: Val::Px(BOARD_SIZE - LINE_THICKNESS),
+                        height: Val::Px(BOARD_SIZE - LINE_THICKNESS),
                         ..Default::default()
                     })
                     .with_children(|parent| {
                         parent
                             .spawn((
                                 GridNode,
-                                NodeBundle {
-                                    style: Style {
-                                        display: Display::Grid,
-                                        grid_template_columns: vec![GridTrack::auto(); GRID_SIZE],
-                                        ..Default::default()
-                                    },
+                                Node {
+                                    display: Display::Grid,
+                                    grid_template_columns: vec![GridTrack::auto(); GRID_SIZE],
                                     ..Default::default()
                                 },
                             ))
                             .with_children(|parent| {
                                 for _ in 0..GRID_SIZE * GRID_SIZE {
-                                    parent.spawn(ButtonBundle {
-                                        style: Style {
+                                    parent.spawn((
+                                        Button,
+                                        Node {
                                             width: Val::Px(BUTTON_SIZE),
                                             height: Val::Px(BUTTON_SIZE),
                                             margin: UiRect::all(Val::Px(BUTTON_MARGIN)),
                                             ..Default::default()
                                         },
-                                        background_color: BACKGROUND_COLOR.into(),
-                                        ..Default::default()
-                                    });
+                                        BackgroundColor(BACKGROUND_COLOR.into()),
+                                    ));
                                 }
                             });
 
                         parent
-                            .spawn(NodeBundle {
-                                style: Style {
-                                    margin: UiRect::top(Val::Px(20.0)),
-                                    justify_content: JustifyContent::Center,
-                                    ..Default::default()
-                                },
+                            .spawn(Node {
+                                margin: UiRect::top(Val::Px(20.0)),
+                                justify_content: JustifyContent::Center,
                                 ..Default::default()
                             })
                             .with_children(|parent| {
-                                parent.spawn((
-                                    TextBundle::from_sections([
-                                        TextSection::new(
-                                            String::new(),
-                                            TextStyle {
-                                                font_size: FONT_SIZE,
-                                                color: TEXT_COLOR,
-                                                ..Default::default()
-                                            },
-                                        ),
-                                        TextSection::new(
-                                            String::new(),
-                                            TextStyle {
-                                                font: symbol_font.0.clone(),
-                                                font_size: FONT_SIZE,
-                                                ..Default::default()
-                                            },
-                                        ),
-                                    ]),
-                                    BottomText,
-                                ));
+                                parent
+                                    .spawn((
+                                        Text::default(),
+                                        TextFont {
+                                            font_size: FONT_SIZE,
+                                            ..Default::default()
+                                        },
+                                        TextColor(TEXT_COLOR),
+                                        BottomText,
+                                    ))
+                                    .with_child((
+                                        TextSpan::default(),
+                                        TextFont {
+                                            font: symbol_font.0.clone(),
+                                            font_size: FONT_SIZE,
+                                            ..Default::default()
+                                        },
+                                        TextColor(TEXT_COLOR),
+                                    ));
                             });
                     });
             });
@@ -247,8 +229,8 @@ impl TicTacToePlugin {
         match *cli {
             Cli::Hotseat => {
                 // Set all players to server to play from a single machine and start the game right away.
-                commands.spawn(PlayerBundle::server(Symbol::Cross));
-                commands.spawn(PlayerBundle::server(Symbol::Nought));
+                commands.spawn((Player(ClientId::SERVER), Symbol::Cross));
+                commands.spawn((Player(ClientId::SERVER), Symbol::Nought));
                 game_state.set(GameState::InGame);
             }
             Cli::Server { port, symbol } => {
@@ -274,7 +256,7 @@ impl TicTacToePlugin {
 
                 commands.insert_resource(server);
                 commands.insert_resource(transport);
-                commands.spawn(PlayerBundle::server(symbol));
+                commands.spawn((Player(ClientId::SERVER), symbol));
             }
             Cli::Client { port, ip } => {
                 let server_channels_config = channels.get_server_configs();
@@ -306,41 +288,55 @@ impl TicTacToePlugin {
         Ok(())
     }
 
-    fn show_turn_text(mut bottom_text: Query<&mut Text, With<BottomText>>) {
-        bottom_text.single_mut().sections[0].value = "Current turn: ".into();
+    fn show_turn_text(mut writer: TextUiWriter, bottom_text: Query<Entity, With<BottomText>>) {
+        let text_entity = bottom_text.single();
+        *writer.text(text_entity, TEXT_SECTION) = "Current turn: ".into();
     }
 
     fn show_turn_symbol(
-        mut bottom_text: Query<&mut Text, With<BottomText>>,
+        mut writer: TextUiWriter,
         current_turn: Res<CurrentTurn>,
+        bottom_text: Query<Entity, With<BottomText>>,
     ) {
-        let symbol_section = &mut bottom_text.single_mut().sections[SYMBOL_SECTION];
-        symbol_section.value = current_turn.glyph().into();
-        symbol_section.style.color = current_turn.color();
+        let text_entity = bottom_text.single();
+        *writer.text(text_entity, SYMBOL_SECTION) = current_turn.glyph().into();
+        *writer.color(text_entity, SYMBOL_SECTION) = current_turn.color().into();
     }
 
-    fn show_disconnected_text(mut bottom_text: Query<&mut Text, With<BottomText>>) {
-        let sections = &mut bottom_text.single_mut().sections;
-        sections[TEXT_SECTION].value = "Client disconnected".into();
-        sections[SYMBOL_SECTION].value.clear();
+    fn show_disconnected_text(
+        mut writer: TextUiWriter,
+        bottom_text: Query<Entity, With<BottomText>>,
+    ) {
+        let text_entity = bottom_text.single();
+        *writer.text(text_entity, TEXT_SECTION) = "Client disconnected".into();
+        writer.text(text_entity, SYMBOL_SECTION).clear();
     }
 
-    fn show_winner_text(mut bottom_text: Query<&mut Text, With<BottomText>>) {
-        bottom_text.single_mut().sections[TEXT_SECTION].value = "Winner: ".into();
+    fn show_winner_text(mut writer: TextUiWriter, bottom_text: Query<Entity, With<BottomText>>) {
+        let text_entity = bottom_text.single();
+        *writer.text(text_entity, TEXT_SECTION) = "Winner: ".into();
     }
 
-    fn show_tie_text(mut bottom_text: Query<&mut Text, With<BottomText>>) {
-        let sections = &mut bottom_text.single_mut().sections;
-        sections[TEXT_SECTION].value = "Tie".into();
-        sections[SYMBOL_SECTION].value.clear();
+    fn show_tie_text(mut writer: TextUiWriter, bottom_text: Query<Entity, With<BottomText>>) {
+        let text_entity = bottom_text.single();
+        *writer.text(text_entity, TEXT_SECTION) = "Tie".into();
+        writer.text(text_entity, SYMBOL_SECTION).clear();
     }
 
-    fn show_connecting_text(mut bottom_text: Query<&mut Text, With<BottomText>>) {
-        bottom_text.single_mut().sections[TEXT_SECTION].value = "Connecting".into();
+    fn show_connecting_text(
+        mut writer: TextUiWriter,
+        bottom_text: Query<Entity, With<BottomText>>,
+    ) {
+        let text_entity = bottom_text.single();
+        *writer.text(text_entity, TEXT_SECTION) = "Connecting".into();
     }
 
-    fn show_waiting_player_text(mut bottom_text: Query<&mut Text, With<BottomText>>) {
-        bottom_text.single_mut().sections[TEXT_SECTION].value = "Waiting player".into();
+    fn show_waiting_player_text(
+        mut writer: TextUiWriter,
+        bottom_text: Query<Entity, With<BottomText>>,
+    ) {
+        let text_entity = bottom_text.single();
+        *writer.text(text_entity, TEXT_SECTION) = "Waiting player".into();
     }
 
     /// Waits for client to connect to start the game or disconnect to finish it.
@@ -356,7 +352,7 @@ impl TicTacToePlugin {
             match event {
                 ServerEvent::ClientConnected { client_id } => {
                     let server_symbol = players.single();
-                    commands.spawn(PlayerBundle::new(*client_id, server_symbol.next()));
+                    commands.spawn((Player(*client_id), server_symbol.next()));
                     game_state.set(GameState::InGame);
                 }
                 ServerEvent::ClientDisconnected { .. } => {
@@ -461,16 +457,15 @@ impl TicTacToePlugin {
                 .remove::<Interaction>()
                 .add_child(symbol_entity);
 
-            commands
-                .entity(symbol_entity)
-                .insert(TextBundle::from_section(
-                    symbol.glyph(),
-                    TextStyle {
-                        font: symbol_font.0.clone(),
-                        font_size: 80.0,
-                        color: symbol.color(),
-                    },
-                ));
+            commands.entity(symbol_entity).insert((
+                Text::new(symbol.glyph()),
+                TextFont {
+                    font: symbol_font.0.clone(),
+                    font_size: 65.0,
+                    ..Default::default()
+                },
+                TextColor(symbol.color()),
+            ));
         }
     }
 
@@ -650,30 +645,9 @@ impl SymbolBundle {
 #[derive(Component, Deserialize, Serialize)]
 struct CellIndex(usize);
 
-/// Contains player ID and it's playing symbol.
-#[derive(Bundle)]
-struct PlayerBundle {
-    player: Player,
-    symbol: Symbol,
-    replicated: Replicated,
-}
-
-impl PlayerBundle {
-    fn new(client_id: ClientId, symbol: Symbol) -> Self {
-        Self {
-            player: Player(client_id),
-            symbol,
-            replicated: Replicated,
-        }
-    }
-
-    /// Same as [`Self::new`], but with [`ClientId::SERVER`].
-    fn server(symbol: Symbol) -> Self {
-        Self::new(ClientId::SERVER, symbol)
-    }
-}
-
+/// Contains player ID.
 #[derive(Component, Serialize, Deserialize)]
+#[require(Symbol, Replicated)]
 struct Player(ClientId);
 
 /// An event that indicates a symbol pick.

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,10 +1,8 @@
 use bevy::prelude::*;
+#[cfg(feature = "renet_netcode")]
+use bevy_renet::netcode::{NetcodeClientPlugin, NetcodeClientTransport};
 use bevy_renet::{self, renet::RenetClient, RenetClientPlugin, RenetReceive, RenetSend};
-#[cfg(feature = "renet_transport")]
-use bevy_renet::{renet::transport::NetcodeClientTransport, transport::NetcodeClientPlugin};
 use bevy_replicon::prelude::*;
-
-use crate::ClientIdExt;
 
 /// Adds renet as client messaging backend.
 ///
@@ -35,7 +33,7 @@ impl Plugin for RepliconRenetClientPlugin {
                     .run_if(bevy_renet::client_connected),
             );
 
-        #[cfg(feature = "renet_transport")]
+        #[cfg(feature = "renet_netcode")]
         app.add_plugins(NetcodeClientPlugin);
     }
 }
@@ -53,13 +51,13 @@ impl RepliconRenetClientPlugin {
 
     fn set_connected(
         mut client: ResMut<RepliconClient>,
-        #[cfg(feature = "renet_transport")] transport: Res<NetcodeClientTransport>,
+        #[cfg(feature = "renet_netcode")] transport: Res<NetcodeClientTransport>,
     ) {
         // In renet only transport knows the ID.
         // TODO: Pending renet issue https://github.com/lucaspoffo/renet/issues/153
-        #[cfg(feature = "renet_transport")]
-        let client_id = Some(transport.client_id().to_replicon());
-        #[cfg(not(feature = "renet_transport"))]
+        #[cfg(feature = "renet_netcode")]
+        let client_id = Some(ClientId::new(transport.client_id()));
+        #[cfg(not(feature = "renet_netcode"))]
         let client_id = None;
 
         client.set_status(RepliconClientStatus::Connected { client_id });

--- a/src/client.rs
+++ b/src/client.rs
@@ -2,7 +2,7 @@ use bevy::prelude::*;
 #[cfg(feature = "renet_netcode")]
 use bevy_renet::netcode::{NetcodeClientPlugin, NetcodeClientTransport};
 #[cfg(feature = "renet_steam")]
-use bevy_renet::netcode::{SteamClientPlugin, SteamClientTransport};
+use bevy_renet::steam::SteamClientPlugin;
 use bevy_renet::{self, renet::RenetClient, RenetClientPlugin, RenetReceive, RenetSend};
 use bevy_replicon::prelude::*;
 
@@ -55,25 +55,14 @@ impl RepliconRenetClientPlugin {
 
     fn set_connected(
         mut client: ResMut<RepliconClient>,
-        #[cfg(feature = "renet_netcode")] netcode_transport: Option<Res<NetcodeClientTransport>>,
-        #[cfg(feature = "renet_steam")] steam_transport: Option<Res<SteamClientTransport>>,
+        #[cfg(feature = "renet_netcode")] transport: Option<Res<NetcodeClientTransport>>,
     ) {
         // In renet only transport knows the ID.
         // TODO: Pending renet issue https://github.com/lucaspoffo/renet/issues/153
-        #[allow(unused_mut)]
-        let mut client_id = None;
         #[cfg(feature = "renet_netcode")]
-        if let Some(transport) = netcode_transport {
-            client_id = Some(ClientId::new(transport.client_id()));
-        }
-        #[cfg(feature = "renet_steam")]
-        if let Some(transport) = steam_transport {
-            assert!(
-                client_id.is_none(),
-                "two transports can't be active at the same time",
-            );
-            client_id = Some(ClientId::new(transport.client_id()));
-        }
+        let client_id = transport.map(|transport| ClientId::new(transport.client_id()));
+        #[cfg(not(feature = "renet_netcode"))]
+        let client_id = None;
 
         client.set_status(RepliconClientStatus::Connected { client_id });
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,9 +81,10 @@ pub mod client;
 #[cfg(feature = "server")]
 pub mod server;
 
+#[cfg(feature = "renet_netcode")]
+pub use bevy_renet::netcode;
+
 pub use bevy_renet::renet;
-#[cfg(feature = "renet_transport")]
-pub use bevy_renet::transport;
 
 use bevy::{app::PluginGroupBuilder, prelude::*};
 use bevy_replicon::prelude::*;
@@ -135,30 +136,6 @@ impl RenetChannelsExt for RepliconChannels {
 
     fn get_client_configs(&self) -> Vec<ChannelConfig> {
         create_configs(self.client_channels(), self.default_max_bytes)
-    }
-}
-
-/// External trait for [`ClientId`] to provide convenient conversion into [`renet::ClientId`].
-pub trait RenetClientIdExt {
-    /// Returns renet's Client ID.
-    fn to_renet(&self) -> renet::ClientId;
-}
-
-impl RenetClientIdExt for ClientId {
-    fn to_renet(&self) -> renet::ClientId {
-        renet::ClientId::from_raw(self.get())
-    }
-}
-
-/// External trait for [`renet::ClientId`] to provide convenient conversion into [`ClientId`].
-pub trait ClientIdExt {
-    /// Returns replicon's Client ID.
-    fn to_replicon(&self) -> ClientId;
-}
-
-impl ClientIdExt for renet::ClientId {
-    fn to_replicon(&self) -> ClientId {
-        ClientId::new(self.raw())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,8 +34,8 @@ If the `renet_transport` feature is enabled, netcode plugins will also be automa
 ## Server and client creation
 
 To connect to the server or create it, you need to initialize the
-[`RenetClient`](renet::RenetClient) and [`NetcodeClientTransport`](renet::transport::NetcodeClientTransport) **or**
-[`RenetServer`](renet::RenetServer) and [`NetcodeServerTransport`](renet::transport::NetcodeServerTransport)
+[`RenetClient`](renet::RenetClient) and [`NetcodeClientTransport`](bevy_renet::netcode::NetcodeClientTransport) **or**
+[`RenetServer`](renet::RenetServer) and [`NetcodeServerTransport`](bevy_renet::netcode::NetcodeServerTransport)
 resources from Renet.
 
 Never insert client and server resources in the same app for single-player, it will cause a replication loop.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,8 @@ To connect to the server or create it, you need to initialize the
 [`RenetServer`](renet::RenetServer) and [`NetcodeServerTransport`](bevy_renet::netcode::NetcodeServerTransport)
 resources from Renet.
 
+For steam transport you need to activate the corresponding and use its transport resource instead.
+
 Never insert client and server resources in the same app for single-player, it will cause a replication loop.
 
 This crate provides the [`RenetChannelsExt`] extension trait to conveniently convert channels

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,8 +83,9 @@ pub mod server;
 
 #[cfg(feature = "renet_netcode")]
 pub use bevy_renet::netcode;
-
 pub use bevy_renet::renet;
+#[cfg(feature = "renet_steam")]
+pub use bevy_renet::steam;
 
 use bevy::{app::PluginGroupBuilder, prelude::*};
 use bevy_replicon::prelude::*;

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,6 +1,8 @@
 use bevy::prelude::*;
 #[cfg(feature = "renet_netcode")]
 use bevy_renet::netcode::NetcodeServerPlugin;
+#[cfg(feature = "renet_steam")]
+use bevy_renet::netcode::SteamServerPlugin;
 use bevy_renet::{
     renet::{self, RenetServer},
     RenetReceive, RenetSend, RenetServerPlugin,
@@ -40,6 +42,8 @@ impl Plugin for RepliconRenetServerPlugin {
 
         #[cfg(feature = "renet_netcode")]
         app.add_plugins(NetcodeServerPlugin);
+        #[cfg(feature = "renet_steam")]
+        app.add_plugins(SteamServerPlugin);
     }
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -2,7 +2,7 @@ use bevy::prelude::*;
 #[cfg(feature = "renet_netcode")]
 use bevy_renet::netcode::NetcodeServerPlugin;
 #[cfg(feature = "renet_steam")]
-use bevy_renet::netcode::SteamServerPlugin;
+use bevy_renet::steam::SteamServerPlugin;
 use bevy_renet::{
     renet::{self, RenetServer},
     RenetReceive, RenetSend, RenetServerPlugin,

--- a/tests/netcode.rs
+++ b/tests/netcode.rs
@@ -4,12 +4,12 @@ use std::{
 };
 
 use bevy::prelude::*;
-use bevy_renet::renet::{
-    transport::{
+use bevy_renet::{
+    netcode::{
         ClientAuthentication, NetcodeClientTransport, NetcodeServerTransport, ServerAuthentication,
         ServerConfig,
     },
-    ConnectionConfig, RenetClient, RenetServer,
+    renet::{ConnectionConfig, RenetClient, RenetServer},
 };
 use bevy_replicon::prelude::*;
 use bevy_replicon_renet::{RenetChannelsExt, RepliconRenetPlugins};


### PR DESCRIPTION
Still waiting for latest tagged release of [renet](https://github.com/lucaspoffo/renet).

## Changes

`transport` in renet was moved under `netcode` in latest version of `bevy_renet`, ref.: https://github.com/lucaspoffo/renet/commit/042ede98f13dc3a5aa54f986f99abec128041232#diff-f615dba06c307102205077c64d4ac874279d20c882f5319a57874951e4c1af3aR15. And `serde` is no longer required by `bevy_renet`. This adjusts for both. Also `renet` `ClientId` is now just type alias for `u64` so that part can be simplified.

This removes `renet_serde`, and `renet_transport` in favor of `renet_netcode`.