### PR TITLE
Update to `bevy_replicon` 0.34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Trigger disconnect when entities with `ConnectedClient` are despawned.
+
 ## [0.9.0] - 2025-03-24
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Update to `bevy_replicon` 0.34.
 - Trigger disconnect when entities with `ConnectedClient` are despawned.
 
 ## [0.9.0] - 2025-03-24

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 all-features = true
 
 [dependencies]
-bevy_replicon = { version = "0.33", default-features = false }
+bevy_replicon = { version = "0.34.0-rc.1", default-features = false }
 bevy_renet = { git = "https://github.com/lucaspoffo/renet", default-features = false }
 bevy = { version = "0.16", default-features = false, features = ["bevy_log"] }
 

--- a/examples/simple_box.rs
+++ b/examples/simple_box.rs
@@ -39,7 +39,7 @@ fn main() {
         .add_observer(spawn_clients)
         .add_observer(despawn_clients)
         .add_observer(apply_movement)
-        .add_systems(Startup, (read_cli.map(Result::unwrap), spawn_camera))
+        .add_systems(Startup, (read_cli, spawn_camera))
         .add_systems(Update, (read_input, draw_boxes))
         .run();
 }

--- a/examples/tic_tac_toe.rs
+++ b/examples/tic_tac_toe.rs
@@ -9,7 +9,6 @@ use std::{
 
 use bevy::{
     ecs::{relationship::RelatedSpawner, spawn::SpawnWith},
-    platform::collections::HashMap,
     prelude::*,
 };
 use bevy_replicon::prelude::*;
@@ -36,10 +35,9 @@ fn main() {
                 }),
                 ..Default::default()
             }),
-            RepliconPlugins.set(ServerPlugin {
-                // We start replication manually because we want to exchange cell mappings first.
-                replicate_after_connect: false,
-                ..Default::default()
+            RepliconPlugins.set(RepliconSharedPlugin {
+                // Customize authorization because we want to exchange cell mappings first.
+                auth_method: AuthMethod::Custom,
             }),
             RepliconRenetPlugins,
         ))
@@ -47,8 +45,8 @@ fn main() {
         .init_resource::<SymbolFont>()
         .init_resource::<TurnSymbol>()
         .replicate::<Symbol>()
+        .add_client_trigger::<ClientInfo>(Channel::Ordered)
         .add_client_trigger::<CellPick>(Channel::Ordered)
-        .add_client_trigger::<MapCells>(Channel::Ordered)
         .add_server_trigger::<MakeLocal>(Channel::Ordered)
         .insert_resource(ClearColor(BACKGROUND_COLOR))
         .add_observer(disconnect_by_client)
@@ -57,7 +55,7 @@ fn main() {
         .add_observer(apply_pick)
         .add_observer(init_symbols)
         .add_observer(advance_turn)
-        .add_systems(Startup, (setup_ui, read_cli.map(Result::unwrap)))
+        .add_systems(Startup, (setup_ui, read_cli))
         .add_systems(
             OnEnter(GameState::InGame),
             (show_turn_text, show_turn_symbol),
@@ -361,13 +359,18 @@ fn init_symbols(
 /// server to receive replication to already existing entities.
 ///
 /// Used only for client.
-fn client_start(mut commands: Commands, cells: Query<(Entity, &Cell)>) {
-    let mut entities = HashMap::new();
-    for (entity, cell) in &cells {
-        entities.insert(cell.index, entity);
-    }
+fn client_start(
+    mut commands: Commands,
+    protocol: Res<ProtocolHash>,
+    cells: Query<(Entity, &Cell)>,
+) {
+    let mut cells: Vec<_> = cells.iter().collect();
+    cells.sort_by_key(|(_, cell)| cell.index);
 
-    commands.client_trigger(MapCells(entities));
+    commands.client_trigger(ClientInfo {
+        protocol: *protocol,
+        cells: cells.into_iter().map(|(entity, _)| entity).collect(),
+    });
     commands.set_state(GameState::InGame);
 }
 
@@ -375,23 +378,38 @@ fn client_start(mut commands: Commands, cells: Query<(Entity, &Cell)>) {
 ///
 /// Used only for server.
 fn init_client(
-    trigger: Trigger<FromClient<MapCells>>,
+    trigger: Trigger<FromClient<ClientInfo>>,
     mut commands: Commands,
+    mut events: EventWriter<DisconnectRequest>,
+    protocol: Res<ProtocolHash>,
     cells: Query<(Entity, &Cell)>,
     server_symbol: Single<&Symbol, With<LocalPlayer>>,
 ) {
-    // Usually entity map modified directly on an connected client entity,
-    // it's a required component of `ReplicatedClient`.
-    // But since we set `replicate_after_connect` to `false`,
-    // we insert it together with `ReplicatedClient`.
-    let mut entity_map = ClientEntityMap::default();
-    for (server_entity, cell) in &cells {
-        let Some(&client_entity) = trigger.get(&cell.index) else {
-            error!("received cells missing index {}, disconnecting", cell.index);
-            commands.set_state(GameState::Disconnected);
-            return;
-        };
+    // Since we using custom authorization,
+    // we need to verify the protocol manually.
+    if trigger.protocol != *protocol {
+        // Notify client about the problem. No delivery
+        // guarantee since we disconnect after sending.
+        commands.server_trigger(ToClients {
+            mode: SendMode::Direct(trigger.client_entity),
+            event: ProtocolMismatch,
+        });
+        events.write(DisconnectRequest {
+            client_entity: trigger.client_entity,
+        });
+    }
 
+    // Sort local square entities to match them with the received.
+    let mut cells: Vec<_> = cells.iter().collect();
+    cells.sort_by_key(|(_, cell)| cell.index);
+
+    // This map is a required component for `AuthorizedClient`.
+    // By default it's empty, but we can initialize it with the
+    // received entities.
+    let mut entity_map = ClientEntityMap::default();
+    for (&server_entity, &client_entity) in
+        cells.iter().map(|(entity, _)| entity).zip(&trigger.cells)
+    {
         entity_map.insert(server_entity, client_entity);
     }
 
@@ -399,7 +417,7 @@ fn init_client(
     commands.entity(trigger.client_entity).insert((
         Player,
         server_symbol.next(),
-        ReplicatedClient,
+        AuthorizedClient,
         entity_map,
     ));
 
@@ -685,11 +703,14 @@ struct CellPick {
     index: usize,
 }
 
-/// A trigger to send client cell entities to server to estabialize mappings for replication.
+/// A client trigger with protocol information and client's chess board entities.
 ///
 /// See [`client_start`] for details.
-#[derive(Event, Deref, Serialize, Deserialize)]
-struct MapCells(HashMap<usize, Entity>);
+#[derive(Event, Serialize, Deserialize)]
+struct ClientInfo {
+    protocol: ProtocolHash,
+    cells: Vec<Entity>,
+}
 
 /// A trigger that instructs the client to mark a specific entity as [`LocalPlayer`].
 #[derive(Event, Serialize, Deserialize)]

--- a/examples/tic_tac_toe.rs
+++ b/examples/tic_tac_toe.rs
@@ -374,7 +374,7 @@ fn client_start(
     commands.set_state(GameState::InGame);
 }
 
-/// Estabializes mappings between spawned client and server entities and starts the game.
+/// Establishes mappings between spawned client and server entities and starts the game.
 ///
 /// Used only for server.
 fn init_client(

--- a/src/client.rs
+++ b/src/client.rs
@@ -20,8 +20,6 @@ impl Plugin for RepliconRenetClientPlugin {
             .add_systems(
                 PreUpdate,
                 (
-                    set_connecting.run_if(bevy_renet::client_connecting),
-                    set_disconnected.run_if(bevy_renet::client_just_disconnected),
                     set_connected.run_if(bevy_renet::client_just_connected),
                     receive_packets.run_if(bevy_renet::client_connected),
                 )
@@ -30,9 +28,16 @@ impl Plugin for RepliconRenetClientPlugin {
             )
             .add_systems(
                 PostUpdate,
-                send_packets
-                    .in_set(ClientSet::SendPackets)
-                    .run_if(bevy_renet::client_connected),
+                (
+                    (
+                        set_connecting.run_if(bevy_renet::client_connecting),
+                        set_disconnected.run_if(bevy_renet::client_just_disconnected),
+                    )
+                        .before(ClientSet::Send),
+                    send_packets
+                        .in_set(ClientSet::SendPackets)
+                        .run_if(bevy_renet::client_connected),
+                ),
             );
 
         #[cfg(feature = "renet_netcode")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,11 +176,11 @@ pub trait RenetChannelsExt {
     ///
     /// ```
     /// # use bevy::prelude::*;
-    /// # use bevy_replicon::{prelude::*, shared::backend::replicon_channels::ReplicationChannel};
+    /// # use bevy_replicon::{prelude::*, shared::backend::replicon_channels::ServerChannel};
     /// # use bevy_replicon_renet::RenetChannelsExt;
     /// # let channels = RepliconChannels::default();
     /// let mut server_configs = channels.server_configs();
-    /// let channel = &mut server_configs[ReplicationChannel::Updates as usize];
+    /// let channel = &mut server_configs[ServerChannel::Updates as usize];
     /// channel.max_memory_usage_bytes = 4090;
     /// ```
     fn server_configs(&self) -> Vec<ChannelConfig>;

--- a/src/server.rs
+++ b/src/server.rs
@@ -23,6 +23,7 @@ impl Plugin for RepliconRenetServerPlugin {
         app.add_plugins(RenetServerPlugin)
             .configure_sets(PreUpdate, ServerSet::ReceivePackets.after(RenetReceive))
             .configure_sets(PostUpdate, ServerSet::SendPackets.before(RenetSend))
+            .add_observer(disconnect_client)
             .add_systems(
                 PreUpdate,
                 (
@@ -57,7 +58,7 @@ fn set_stopped(mut server: ResMut<RepliconServer>) {
     server.set_running(false);
 }
 
-fn forward_server_events(
+fn process_server_events(
     mut commands: Commands,
     mut server_events: EventReader<ServerEvent>,
     network_map: Res<NetworkIdMap>,
@@ -75,16 +76,15 @@ fn forward_server_events(
                         network_id,
                     ))
                     .id();
-                debug!("connecting `{client_entity}` with `{network_id:?}`");
+                debug!("spawning client `{client_entity}` with `{network_id:?}`");
             }
             ServerEvent::ClientDisconnected { client_id, reason } => {
                 let network_id = NetworkId::new(*client_id);
-                let client_entity = *network_map
-                    .get(&network_id)
-                    .expect("clients should be connected before disconnection");
-
-                commands.entity(client_entity).despawn();
-                debug!("disconnecting `{client_entity}` with `{network_id:?}`: {reason}");
+                if let Some(&client_entity) = network_map.get(&network_id) {
+                    // Entity could have been despawned by user.
+                    commands.entity(client_entity).despawn();
+                    debug!("despawning client `{client_entity}` with `{network_id:?}`: {reason}");
+                }
             }
         }
     }
@@ -131,5 +131,20 @@ fn send_packets(
             .get(client_entity)
             .expect("messages should be sent only to connected clients");
         renet_server.send_message(network_id.get(), channel_id as u8, message)
+    }
+}
+
+fn disconnect_client(
+    trigger: Trigger<OnRemove, ConnectedClient>,
+    server: Option<ResMut<RenetServer>>,
+    clients: Query<&NetworkId>,
+) {
+    if let Some(mut server) = server {
+        debug!("disconnecting despawned client `{}`", trigger.target());
+
+        let network_id = clients
+            .get(trigger.target())
+            .expect("inserted on connection");
+        server.disconnect(network_id.get());
     }
 }


### PR DESCRIPTION
First commit is not related to the changes in Replicon, but needed to handle disconnects nicely.

## Summary of changes:

- React on `DisconnectRequest` event.
  Relevant PR:
  https://github.com/projectharmonia/bevy_replicon/pull/491
- Process received data on disconnect.
  Relevant PR:
  https://github.com/projectharmonia/bevy_replicon/pull/494
- Update examples.
  Relevant PRs:
  https://github.com/projectharmonia/bevy_replicon/pull/498
  https://github.com/projectharmonia/bevy_replicon/pull/479
- Update tests.
  - Move server stopping into a separate test.
    Relevant PR:
    https://github.com/projectharmonia/bevy_replicon/pull/494
  - Add `finish` calls. Required to initialize channels.
    Relevant PR:
    https://github.com/projectharmonia/bevy_replicon/pull/488
  - Test `DisconnectRequest`.
    Relevant PR:
    https://github.com/projectharmonia/bevy_replicon/pull/491
  - Remove uses of the word "Dummy".
    Relevant PR:
    https://github.com/projectharmonia/bevy_replicon/pull/486